### PR TITLE
Close output content with semicolon

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,7 @@ export default function loader(
         null,
         `${
             options.esModule ? "export default" : "module.exports ="
-        } ${JSON.stringify(output)}`
+        } ${JSON.stringify(output)};`
     );
 }
 


### PR DESCRIPTION
Output isn't closed with a semicolon (`;`), which causes compilation issues with strict language checking.